### PR TITLE
s/credentialsProviderProvider/credentialsProviderFactory/

### DIFF
--- a/sched-assist-war/src/main/resources/contexts/integration/calendarData-caldav.xml
+++ b/sched-assist-war/src/main/resources/contexts/integration/calendarData-caldav.xml
@@ -51,7 +51,7 @@
 	<!-- END: Bedework Specific beans -->
 	<!-- If using a CalDAV server other than Bedework, look in localOverridesContext.xml for other options -->
 	
-	<bean id="credentialsProviderProvider" class="org.jasig.schedassist.impl.caldav.DefaultCredentialsProviderProviderImpl"/>	
+	<bean id="credentialsProviderFactory" class="org.jasig.schedassist.impl.caldav.DefaultCredentialsProviderFactoryImpl"/>	
 	<bean id="affiliationSource" class="org.jasig.schedassist.NullAffiliationSourceImpl"/>
 	<bean id="visibleScheduleBuilder" class="org.jasig.schedassist.model.VisibleScheduleBuilder">
 		<property name="eventUtils" ref="eventUtils"/>


### PR DESCRIPTION
- org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'schedulingAssistantEndpoint': Injection of autowired dependencies failed;
- nested exception is org.springframework.beans.factory.BeanCreationException: Could not autowire method: public void org.jasig.schedassist.remoting.soap.SOAPSchedulingAssistantServiceEndpoint.setAvailableService(org.jasig.schedassist.SchedulingAssistantService);
- nested exception is org.springframework.beans.factory.CannotLoadBeanClassException: Cannot find class [org.jasig.schedassist.impl.caldav.DefaultCredentialsProviderProviderImpl] for bean with name 'credentialsProviderProvider' defined in file [/opt/services/apache-tomcat-local/webapps/nrao-scheduling-assistant/WEB-INF/classes/contexts/integration/calendarData-caldav.xml];
- nested exception is java.lang.ClassNotFoundException: org.jasig.schedassist.impl.caldav.DefaultCredentialsProviderProviderImpl
