### PR TITLE
Support uid attribute in HTTP paths.

### DIFF
--- a/sched-assist-spi-caldav/src/main/java/org/jasig/schedassist/impl/caldav/DefaultCaldavDialectImpl.java
+++ b/sched-assist-spi-caldav/src/main/java/org/jasig/schedassist/impl/caldav/DefaultCaldavDialectImpl.java
@@ -65,7 +65,7 @@ public class DefaultCaldavDialectImpl implements CaldavDialect{
 	private String accountHomePrefix = "/ucaldav/user/";
 	private String accountHomeSuffix = "/calendar/";
 	private IEventUtils eventUtils;
-	
+	private String userPathSegmentAttributeName = "uid";
 	private Log log = LogFactory.getLog(this.getClass());
 	
 	/**
@@ -92,8 +92,19 @@ public class DefaultCaldavDialectImpl implements CaldavDialect{
 	public void setAccountHomeSuffix(String accountHomeSuffix) {
 		this.accountHomeSuffix = accountHomeSuffix;
 	}
-	
-	
+	/**
+	 * 
+	 * @return the userPathSegmentAttributeName
+	 */
+	public String getUserPathSegmentAttributeName() {
+		return userPathSegmentAttributeName;
+	}
+	/**
+	 * @param userPathSegmentAttributeName
+	 */
+	public void setUserPathSegmentAttributeName(String userPathSegmentAttributeName) {
+		this.userPathSegmentAttributeName = userPathSegmentAttributeName;
+	}
 	/* (non-Javadoc)
 	 * @see org.jasig.schedassist.impl.caldav.CaldavDialect#getCaldavHost()
 	 */
@@ -191,13 +202,13 @@ public class DefaultCaldavDialectImpl implements CaldavDialect{
 	@Override
 	public String getCalendarAccountHome(ICalendarAccount calendarAccount) {
 		Validate.notNull(calendarAccount, "calendarAccount argument must not be null");
-		final String accountUsername = calendarAccount.getUsername();
-		Validate.notNull(accountUsername, "username in calendarAccount argument must not be null");
+		final String userPathSegmentAttribute = calendarAccount.getAttributeValue(userPathSegmentAttributeName);
+		Validate.notNull(userPathSegmentAttribute, "userPathSegment attribute (" + userPathSegmentAttributeName + ") in calendarAccount argument must not be null");
 		
 		StringBuilder uri = new StringBuilder();
 		uri.append(getCaldavHost().toString());
 		uri.append(getAccountHomePrefix());
-		uri.append(accountUsername);
+		uri.append(userPathSegmentAttribute);
 		uri.append(getAccountHomeSuffix());
 		return uri.toString();
 	}

--- a/sched-assist-spi-caldav/src/main/java/org/jasig/schedassist/impl/caldav/bedework/BedeworkEventUtilsImpl.java
+++ b/sched-assist-spi-caldav/src/main/java/org/jasig/schedassist/impl/caldav/bedework/BedeworkEventUtilsImpl.java
@@ -19,6 +19,7 @@
 
 package org.jasig.schedassist.impl.caldav.bedework;
 
+import net.fortuna.ical4j.model.Property;
 import net.fortuna.ical4j.model.component.VEvent;
 import net.fortuna.ical4j.model.property.XProperty;
 
@@ -59,6 +60,9 @@ public class BedeworkEventUtilsImpl extends CaldavEventUtilsImpl {
 		VEvent event = super.constructAvailableAppointment(block, owner, visitor,
 				eventDescription);
 		event.getProperties().add(new XProperty(BEDEWORK_SUBMITTEDBY, owner.getCalendarAccount().getUsername()));
+		// don't need an attendee for the owner!
+		Property ownerAttendee = getAttendeeForUserFromEvent(event, owner.getCalendarAccount());
+		event.getProperties().remove(ownerAttendee);
 		return event;
 	}
 

--- a/sched-assist-spi-caldav/src/test/java/org/jasig/schedassist/impl/caldav/CaldavCalendarDataDaoImplTest.java
+++ b/sched-assist-spi-caldav/src/test/java/org/jasig/schedassist/impl/caldav/CaldavCalendarDataDaoImplTest.java
@@ -362,7 +362,7 @@ public class CaldavCalendarDataDaoImplTest {
 
 		CaldavCalendarDataDaoImpl calendarDataDao = new CaldavCalendarDataDaoImpl();
 		ICalendarAccount calendarAccount = mock(ICalendarAccount.class);
-		when(calendarAccount.getUsername()).thenReturn("username");
+		when(calendarAccount.getAttributeValue("uid")).thenReturn("username");
 		when(calendarAccount.getEmailAddress()).thenReturn("username@server.edu");
 		DefaultCaldavDialectImpl dialect = new DefaultCaldavDialectImpl();
 		dialect.setCaldavHost(URI.create("http://localhost:8080/"));

--- a/sched-assist-spi-caldav/src/test/java/org/jasig/schedassist/impl/caldav/DefaultCaldavDialectImplTest.java
+++ b/sched-assist-spi-caldav/src/test/java/org/jasig/schedassist/impl/caldav/DefaultCaldavDialectImplTest.java
@@ -64,7 +64,7 @@ public class DefaultCaldavDialectImplTest {
 		dialect.setCaldavHost(new URI("http://localhost:8080"));
 		
 		MockCalendarAccount calendarAccount = new MockCalendarAccount();
-		calendarAccount.setUsername("somebody");
+		calendarAccount.setAttributeValue(dialect.getUserPathSegmentAttributeName(), "somebody");
 		Assert.assertEquals("http://localhost:8080/ucaldav/user/somebody/calendar/", dialect.getCalendarAccountHome(calendarAccount));
 	}
 	

--- a/sched-assist-war/src/main/resources/contexts/integration/calendarAccounts-ldap.xml
+++ b/sched-assist-war/src/main/resources/contexts/integration/calendarAccounts-ldap.xml
@@ -63,7 +63,14 @@
 	<bean id="calendarAccountDao" class="org.jasig.schedassist.impl.ldap.LDAPCalendarAccountDaoImpl">
 		<property name="ldapTemplate" ref="ldapTemplate"/>
 		<property name="baseDn" ref="userAccountBaseDn"/>
-		<property name="ldapAttributesKey" ref="ldapAttributesKey"/>
+		<property name="ldapAttributesKey">
+			<bean class="org.jasig.schedassist.impl.ldap.LDAPAttributesKeyImpl">
+				<property name="usernameAttributeName" value="mail"/>
+				<property name="uniqueIdentifierAttributeName" value="mail"/>
+				<property name="emailAddressAttributeName" value="mail"/>
+				<property name="displayNameAttributeName" value="cn"/>
+			</bean>
+		</property>
 		<property name="searchResultsLimit" value="${ldap.searchResultsLimit}"/>
 		<property name="searchTimeLimit" value="${ldap.searchTimeLimitMillis}"/>
 		<property name="enforceSpecificObjectClass" value="${ldap.accounts.enforceSpecificObjectClass}"/>

--- a/sched-assist-war/src/main/resources/contexts/security.xml
+++ b/sched-assist-war/src/main/resources/contexts/security.xml
@@ -92,10 +92,26 @@
 		class="org.jasig.schedassist.web.security.CalendarAccountUserDetailsServiceImpl">
 		<property name="administratorListProperty" value="${administrators.list}"/>
 		<property name="identifyingAttributeName" value="uid"/>
-		<property name="activeDisplayNameAttribute" value="uid"/>
-		<!--  
-		<property name="identifyingAttributeName" value="${users.visibleIdentifierAttributeName}"/>
-		-->
+		<property name="activeDisplayNameAttribute" value="mail"/>
+		<!-- use a separate calendarAccountDao that allows for lookup by uid -->
+		<property name="calendarAccountDao">
+			<bean id="calendarAccountDao" class="org.jasig.schedassist.impl.ldap.LDAPCalendarAccountDaoImpl">
+				<property name="ldapTemplate" ref="ldapTemplate"/>
+				<property name="baseDn" ref="userAccountBaseDn"/>
+				<property name="ldapAttributesKey">
+					<bean class="org.jasig.schedassist.impl.ldap.LDAPAttributesKeyImpl">
+						<property name="usernameAttributeName" value="uid"/>
+						<property name="uniqueIdentifierAttributeName" value="mail"/>
+						<property name="emailAddressAttributeName" value="mail"/>
+						<property name="displayNameAttributeName" value="cn"/>
+					</bean>
+				</property>
+				<property name="searchResultsLimit" value="${ldap.searchResultsLimit}"/>
+				<property name="searchTimeLimit" value="${ldap.searchTimeLimitMillis}"/>
+				<property name="enforceSpecificObjectClass" value="${ldap.accounts.enforceSpecificObjectClass}"/>
+				<property name="requiredObjectClass" value="${ldap.accounts.requiredObjectClass}"/>
+			</bean>
+		</property>
 	</bean>
 
 	<bean id="delegateAccountDetailsService"


### PR DESCRIPTION
Fixes a bug that prevents interaction with stock Bedework quickstart.

Add support in the default CalDAV dialect to configure the user attribute used in building the HTTP paths. Alter default configuration to better suit the Bedework quickstart. Remove the unnecessary ATTENDEE property for the schedule owner.
